### PR TITLE
Add 7zip dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # Install poetry and any other dependency that your worker needs.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-poetry \
+    p7zip-full \
     # Add your dependencies here
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add 7zip binary dependency to support workers to use the extract_7zip() function in the openrelik_worker_common library. https://github.com/openrelik/openrelik-worker-common/blob/main/openrelik_worker_common/archives.py#L21