### PR TITLE
Revert "Add 7zip dependency"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # Install poetry and any other dependency that your worker needs.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-poetry \
-    p7zip-full \
     # Add your dependencies here
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Reverts openrelik/openrelik-worker-template#4

Adding a check in the common lib to see if 7zip is installed and raises if not. This enables a smaller template by default. Developers have to include the dependency if they expect to deal with archives.