### PR TITLE
Update app.py to have a redis_url

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,6 @@ from openrelik_worker_common.debug_utils import start_debugger
 if os.getenv("OPENRELIK_PYDEBUG") == "1":
     start_debugger()
 
-REDIS_URL = os.getenv("REDIS_URL")
+REDIS_URL = os.getenv("REDIS_URL") or "redis://localhost:6379/0"
 celery = Celery(broker=REDIS_URL, backend=REDIS_URL, include=["src.tasks"])
 redis_client = redis.Redis.from_url(REDIS_URL)


### PR DESCRIPTION
Fix pytest complaining `REDIS_URL` does not exist